### PR TITLE
🦄 refactor: 로그인, 로그아웃 실행시 리코일 상태 변경

### DIFF
--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -1,46 +1,50 @@
 /* eslint-disable no-console */
 import React, { useEffect, useState } from "react";
-// import { useNavigate } from "react-router-dom";
 import { useNavigate } from "react-router-dom";
 import { useRecoilState, useSetRecoilState } from "recoil";
 
 import Button from "../components/common/button/Button";
 import useApiMutation from "../hooks/useApiMutation";
+import privateDataAtom from "../recoil/privateDataAtom";
 import userDataAtom from "../recoil/userDataAtom";
 
 export default function SignIn() {
+  // * 유저데이터를 가져오기 위한 userDataAtom 사용
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [userData, setUserData] = useRecoilState(userDataAtom);
+  const [privateData, setPrivateData] = useRecoilState(privateDataAtom);
+  const setUserLoginState = useSetRecoilState(userDataAtom);
+  const setUserPrivateState = useSetRecoilState(privateDataAtom);
+
   const navigate = useNavigate();
 
-  // initialUserData에 로컬스토리지에 저장된 유저 데이터를 표시.
+  // * initialUserData에 로컬스토리지에 저장된 유저 데이터를 표시.
   const localStorageData = localStorage.getItem("userData");
   const initialUserData = localStorageData
     ? JSON.parse(localStorageData)
     : userDataAtom.default;
-  const [userData, setUserData] = useRecoilState(userDataAtom);
 
-  // mount시 로컬스토리지에 데이터가 있으면 userData에 저장.
+  // * mount시 로컬스토리지에 데이터가 있으면 userData에 저장.
   useEffect(() => {
     if (initialUserData) {
       setUserData(initialUserData);
     }
   }, []);
 
-  // userData가 변경되면 로컬스토리지 데이터 갱신.
+  // * userData가 변경되면 로컬스토리지 데이터 갱신.
   useEffect(() => {
     if (
       userData &&
       JSON.stringify(userData) !== localStorage.getItem("userData")
     ) {
       localStorage.setItem("userData", JSON.stringify(userData));
-      console.table(userData);
+      localStorage.setItem("privateData", JSON.stringify(privateData));
+      console.table(userData, privateData);
     }
   }, [userData]);
 
-  // recoil을 사용해서 userDataAtom 변경
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const setUserLoginState = useSetRecoilState(userDataAtom);
-
+  // * 로그인 API 호출
   const postUserData = useApiMutation(
     "/user/login",
     "post",
@@ -49,19 +53,18 @@ export default function SignIn() {
       onSuccess: data => {
         console.log("요청에 성공했습니다.");
         setUserLoginState(data.user);
+        setUserPrivateState(data.user.token);
         navigate(`/profile/${data.user.accountname}`);
       },
     },
   );
 
-  // console.log(userData.token);
-  // * 입력값 핸들러
+  // * 로그인 입력값 핸들러함수 실행
   const handleInputChange = (e, setInputChange) => {
     setInputChange(e.target.value);
   };
 
-  // Email, Password 입력시 state 변경하는 Handler 함수
-  // * 로그인 버튼 클릭시 비동기 통신 실행
+  // * 로그인 실행
   const handleSignIn = async e => {
     e.preventDefault();
     if (password.length < 6) {
@@ -74,10 +77,12 @@ export default function SignIn() {
     }
   };
 
-  // * 로그아웃 버튼 클릭시 로컬스토리지 데이터 삭제
+  // * 로그아웃 실행
   const handleSignOut = () => {
     localStorage.removeItem("userData");
+    localStorage.removeItem("privateData");
     setUserData(userDataAtom.default);
+    setPrivateData(privateDataAtom.default);
   };
 
   return (


### PR DESCRIPTION
## Description
### 기능 설명
- Server State(React Query)로 관리
- Client State(Recoil)로 관리
- API 호출과 Private State를 분리해서 상태를 관리하는 전략 사용
- 프로필 수정시 전역 상태가 recoil과 로컬스토리지에 잘 저장되도록 하기 위해 로그인, 프로필설정, 프로필수정 총 3개 페이지에서 전역상태 수정 후 캐싱 실행

### issue
- #11 

## CheckList
