### PR TITLE
✨ feat: 홈, 뉴스레터 페이지 구현

### DIFF
--- a/src/pages/feed/Feed.jsx
+++ b/src/pages/feed/Feed.jsx
@@ -1,5 +1,94 @@
+/* eslint-disable no-underscore-dangle */
 import React from "react";
+import { useLocation } from "react-router-dom";
+import { useRecoilValue } from "recoil";
+
+import Blank from "../../components/blank/Blank";
+import Card from "../../components/common/card/Card";
+import TabBar from "../../components/common/tabBar/TabBar";
+import useApiQuery from "../../hooks/useApiQuery";
+import earthusDataAtom from "../../recoil/earthusDataAtom";
+import userDataAtom from "../../recoil/userDataAtom";
+
+import FeedWrap from "./feed.style";
 
 export default function Feed() {
-  return <div>Feed</div>;
+  const { pathname } = useLocation();
+
+  const earthusData = useRecoilValue(earthusDataAtom);
+  const userData = useRecoilValue(userDataAtom);
+
+  const isNewsletterPage = pathname === "/newsletter";
+
+  const { data: home } = useApiQuery("/post/feed", "get");
+
+  const { data: isFollowing } = useApiQuery(
+    `/profile/${userData.accountname}/following`,
+    "get",
+  );
+
+  const { data: newsletter } = useApiQuery(
+    `/post/${earthusData.accountname}/userpost`,
+    "get",
+  );
+
+  return (
+    <FeedWrap>
+      {/* NewsLetter */}
+      {isNewsletterPage &&
+        newsletter &&
+        newsletter.post.map(v => {
+          return (
+            <Card
+              key={v.id}
+              accountname={v.author.accountname}
+              profileImage={v.author.image}
+              username={v.author.username}
+              id={v.author.accountname}
+              postImage={v.image}
+              content={v.content}
+              heartCount={v.heartCount}
+              commentCount={v.commentCount}
+              time={`${v.createdAt.slice(0, 10).split("-")[0]}년 ${
+                v.createdAt.slice(0, 10).split("-")[1]
+              }월 ${v.createdAt.slice(0, 10).split("-")[2]}일`}
+              postID={v.id}
+              hearted={v.hearted}
+            />
+          );
+        })}
+
+      {/* Home */}
+      {!isNewsletterPage && isFollowing && isFollowing.length === 0 && (
+        <Blank btn="유저 검색하기">유저를 검색해 팔로우 해보세요!</Blank>
+      )}
+      {!isNewsletterPage &&
+        home &&
+        home.posts
+          .filter(v => v.author._id !== earthusData.id)
+          .map(v => {
+            return (
+              <>
+                <Card
+                  key={v.id}
+                  accountname={v.author.accountname}
+                  profileImage={v.author.image}
+                  username={v.author.username}
+                  id={v.author.accountname}
+                  postImage={v.image}
+                  content={v.content}
+                  heartCount={v.heartCount}
+                  commentCount={v.commentCount}
+                  time={`${v.createdAt.slice(0, 10).split("-")[0]}년 ${
+                    v.createdAt.slice(0, 10).split("-")[1]
+                  }월 ${v.createdAt.slice(0, 10).split("-")[2]}일`}
+                  postID={v.id}
+                  hearted={v.hearted}
+                />
+                <TabBar />
+              </>
+            );
+          })}
+    </FeedWrap>
+  );
 }

--- a/src/pages/feed/feed.style.js
+++ b/src/pages/feed/feed.style.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+const FeedWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+`;
+
+export default FeedWrap;

--- a/src/recoil/earthusDataAtom.js
+++ b/src/recoil/earthusDataAtom.js
@@ -1,0 +1,13 @@
+import { atom } from "recoil";
+
+const earthusDataAtom = atom({
+  key: "earthusDataAtom",
+  default: {
+    username: "Earthus",
+    accountname: "earth_us",
+    intro: "얼스어스",
+    id: "648c953ab2cb20566336d0da",
+  },
+});
+
+export default earthusDataAtom;


### PR DESCRIPTION
## Description
### 기능 설명
- useApiQuery 커스텀 훅으로 게시글 api 호출
- 뉴스레터 제공용 계정 Atom
- 라우터별 조건부 렌더링
홈페이지: 뉴스레터 제공용 계정 제외 팔로우한 유저 게시글
뉴스레터: 뉴스레터 제공용 계정 게시글
- 팔로우 없는 경우 Blank 컴포넌트 렌더링

### issue
- #31 

### CheckList
- [ ] 뉴스레터 제공용 계정 Atom 파일