### PR TITLE
✨ feat: 로그인 페이지 구현 [공통]

### DIFF
--- a/src/pages/sign/SignIn.jsx
+++ b/src/pages/sign/SignIn.jsx
@@ -1,5 +1,157 @@
-import React from "react";
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-console */
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useRecoilState, useSetRecoilState } from "recoil";
+
+import Button from "../../components/common/button/Button";
+import Input from "../../components/common/input/Input";
+import useApiMutation from "../../hooks/useApiMutation";
+import privateDataAtom from "../../recoil/privateDataAtom";
+import userDataAtom from "../../recoil/userDataAtom";
+import { getProfileDetailPath, SIGN_UP } from "../../utils/config";
+
+import { H2, SignUpLink } from "./sign.style";
 
 export default function SignIn() {
-  return <div>SignIn</div>;
+  const navigate = useNavigate();
+
+  // 버튼 활성화 상태 관리
+  const [disabledBtn, setDisabledBtn] = useState(true);
+
+  // 인풋필드 상태 저장
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  // 오류 메시지 상태 저장
+  const [emailError, setEmailError] = useState("");
+  const [pwError, setPwError] = useState("");
+
+  // * 유저데이터를 가져오기 위한 userDataAtom 사용
+  const [userData, setUserData] = useRecoilState(userDataAtom);
+  const [privateData, setPrivateData] = useRecoilState(privateDataAtom);
+  const setUserLoginState = useSetRecoilState(userDataAtom);
+  const setUserPrivateState = useSetRecoilState(privateDataAtom);
+
+  // * initialUserData에 로컬스토리지에 저장된 유저 데이터를 표시
+  const localStorageData = localStorage.getItem("userData");
+  const initialUserData = localStorageData
+    ? JSON.parse(localStorageData)
+    : userDataAtom.default;
+
+  // * mount시 로컬스토리지에 데이터가 있으면 userData에 저장
+  useEffect(() => {
+    if (initialUserData) {
+      setUserData(initialUserData);
+    }
+  }, []);
+
+  // * userData가 변경되면 로컬스토리지 데이터 갱신
+  useEffect(() => {
+    if (
+      userData &&
+      JSON.stringify(userData) !== localStorage.getItem("userData")
+    ) {
+      localStorage.setItem("userData", JSON.stringify(userData));
+      localStorage.setItem("privateData", JSON.stringify(privateData));
+      console.table(userData, privateData);
+    }
+  }, [userData]);
+
+  // * 로그인 API 호출
+  const signIn = useApiMutation(
+    "/user/login",
+    "post",
+    { user: { email, password } },
+    {
+      onSuccess: data => {
+        console.log("요청에 성공했습니다.");
+        setPwError(data.message); // "아이디 또는 비밀번호가 일치하지 않습니다."
+        setUserLoginState(data.user);
+        setUserPrivateState(data.user.token);
+        navigate(getProfileDetailPath(data.user.accountname)); // 로그인 시 프로필 페이지로 이동
+      },
+    },
+  );
+
+  // * 로그인 입력값 유효성 검사
+  const validationFields = e => {
+    const currentValue = e.target.value;
+
+    switch (e.target.id) {
+      case "email":
+        setEmail(currentValue);
+        if (currentValue === "") {
+          setEmailError("이메일을 입력해주세요.");
+          setDisabledBtn(true);
+        } else {
+          setEmailError("");
+          setDisabledBtn(false);
+        }
+        break;
+
+      case "password":
+        setPassword(currentValue);
+        if (currentValue === "") {
+          setPwError("비밀번호를 입력해주세요.");
+          setDisabledBtn(true);
+        } else {
+          setPwError("");
+          setDisabledBtn(false);
+        }
+        break;
+
+      default:
+        break;
+    }
+    return null;
+  };
+
+  // * 로그인 실행
+  const handleSignIn = async e => {
+    e.preventDefault();
+    signIn.mutate();
+  };
+
+  return (
+    <section>
+      <H2>로그인</H2>
+      <form onSubmit={handleSignIn}>
+        <Input
+          type="text"
+          id="email"
+          value={email}
+          error={emailError}
+          onChange={validationFields}
+          label="아이디"
+          placeholder="이메일을 입력하세요."
+          required
+          className={
+            emailError === "이메일을 입력해주세요." ||
+            pwError === "이메일 또는 비밀번호가 일치하지 않습니다."
+              ? "error"
+              : ""
+          }
+        />
+        <Input
+          type="password"
+          id="password"
+          value={password}
+          error={pwError}
+          onChange={validationFields}
+          label="비밀번호"
+          placeholder="비밀번호를 입력하세요."
+          required
+        />
+        <Button
+          size="cta"
+          variant={!disabledBtn && email && password ? "primary" : "disabled"}
+          type="submit"
+        >
+          로그인
+        </Button>
+      </form>
+      <SignUpLink to={SIGN_UP}>처음 오셨다면 간편 회원가입 하세요!</SignUpLink>
+    </section>
+  );
 }

--- a/src/pages/sign/sign.style.js
+++ b/src/pages/sign/sign.style.js
@@ -1,0 +1,20 @@
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+
+const H2 = styled.h2`
+  font-size: var(--font-size-title);
+  text-align: center;
+  margin-bottom: 48px;
+`;
+
+const SignUpLink = styled(Link)`
+  position: fixed;
+  bottom: 100px;
+  width: min(100%, var(--size-max-width));
+  margin-left: -16px;
+  text-align: center;
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-46);
+`;
+
+export { H2, SignUpLink };


### PR DESCRIPTION
## Description
### 기능 설명
- 유저 데이터를 가져오기 위한 userDataAtom(리코일) 사용
- mount 시 로컬 스토리지에 유저 데이터가 있으면 변수 userData에 저장
- userData 값이 변경되면 로컬 스토리지 데이터 갱신
- useApiMutation 커스텀 훅으로 로그인 API 요청
- 이메일, 비밀번호 모두 입력했을 경우 버튼 활성화
- 이메일, 비밀번호 입력 안했을 경우, 일치하지 않을 경우 유효성 검사, 에러 메세지 출력

### issue

## CheckList
- [ ] 아래 코드가 없어도 잘 동작하는데 풀 받으시고 확인해주세요 :)
로그인 페이지에서 로컬 스토리지에 유저 데이터가 있는지 확인하는게 맞는지 생각이 드네요!
오히려 스플래쉬 페이지에서 확인하는게 맞지 않을지?!
```
// * initialUserData에 로컬스토리지에 저장된 유저 데이터를 표시
const localStorageData = localStorage.getItem("userData");
const initialUserData = localStorageData
	? JSON.parse(localStorageData)
	: userDataAtom.default;

// * mount시 로컬스토리지에 데이터가 있으면 userData에 저장
useEffect(() => {
	if (initialUserData) {
		setUserData(initialUserData);
	}
}, []);
```