### PR TITLE
🦄 refactor: code splitting 적용

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,7 @@
     "es6": true,
     "node": true
   },
+  "parser": "babel-eslint",
   "extends": [
     "airbnb",
     "plugin:prettier/recommended",
@@ -18,6 +19,7 @@
         "labelAttributes": ["htmlFor"]
       }
     ],
+    "import/first": "off",
     "import/order": [
       "error",
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "eslint": "^8.42.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^8.8.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "build-and-serve": "npm run build && npm run serve"
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "extends": [
       "react-app",
       "react-app/jest"
@@ -49,6 +50,7 @@
     ]
   },
   "devDependencies": {
+    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "eslint": "^8.42.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.8.0",

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -1,30 +1,30 @@
 /* eslint-disable no-undef */
-// import React from "react";
-import React, { Suspense } from "react";
+/* eslint-disable-next-line import/first */
+import React, { Suspense, lazy } from "react";
 import { Routes, Route, Outlet } from "react-router-dom";
 
-import Header from "../components/common/header/Header";
-import TabBar from "../components/common/tabBar/TabBar";
-import ChatList from "../pages/chat/chatList/ChatList";
-import ChatRoom from "../pages/chat/chatRoom/ChatRoom";
-import Error404 from "../pages/error404/Error404";
-import Feed from "../pages/feed/Feed";
-import Follow from "../pages/follow/Follow";
-import Intro from "../pages/intro/Intro";
-import Onboarding from "../pages/onboarding/Onboarding";
-import PostDetail from "../pages/post/postDetail/PostDetail";
-import PostUpload from "../pages/post/postUpload/PostUpload";
-import ProductDetail from "../pages/product/productDetail/ProductDetail";
-import ProductUpload from "../pages/product/productUpload/ProductUpload";
-import ProfileDetail from "../pages/profile/profileDetail/ProfileDetail";
-import ProfileEdit from "../pages/profile/profileEdit/ProfileEdit";
-import Search from "../pages/search/Search";
-import SignIn from "../pages/sign/SignIn";
-import SignUp from "../pages/sign/SignUp";
-import Splash from "../pages/splash/Splash";
+const Header = lazy(() => import("../components/common/header/Header"));
+const TabBar = lazy(() => import("../components/common/tabBar/TabBar"));
+const ChatList = lazy(() => import("../pages/chat/chatList/ChatList"));
+const ChatRoom = lazy(() => import("../pages/chat/chatRoom/ChatRoom"));
+const Error404 = lazy(() => import("../pages/error404/Error404"));
+const Feed = lazy(() => import("../pages/feed/Feed"));
+const Follow = lazy(() => import("../pages/follow/Follow"));
+const Intro = lazy(() => import("../pages/intro/Intro"));
+const Onboarding = lazy(() => import("../pages/onboarding/Onboarding"));
+const PostDetail = lazy(() => import("../pages/post/postDetail/PostDetail"));
+const PostUpload = lazy(() => import("../pages/post/postUpload/PostUpload"));
+const ProductDetail = lazy(() => import("../pages/product/productDetail/ProductDetail"));
+const ProductUpload = lazy(() => import("../pages/product/productUpload/ProductUpload"));
+const ProfileDetail = lazy(() => import("../pages/profile/profileDetail/ProfileDetail"));
+const ProfileEdit = lazy(() => import("../pages/profile/profileEdit/ProfileEdit"));
+const Search = lazy(() => import("../pages/search/Search"));
+const SignIn = lazy(() => import("../pages/sign/SignIn"));
+const SignUp = lazy(() => import("../pages/sign/SignUp"));
+const Splash = lazy(() => import("../pages/splash/Splash"));
 
-import InitRoute from "./InitRoute";
-import PrivateRoute from "./PrivateRoute";
+const InitRoute = lazy(() => import("./InitRoute"));
+const PrivateRoute = lazy(() => import("./PrivateRoute"));
 
 export default function Router() {
   return (


### PR DESCRIPTION
## Description
### 기능 설명
-라이브러리나 모듈들이 모든페이지에 로딩되어 페이지당 많은데이터를 잡아먹는것을 방지하기 위해 여러가지 모듈을 만들어 페이지당 할당시켜주거나, 페이지를 여러가지 모듈에 접근하게 하도록 설정.
- React.lazy를 [React Router](https://reacttraining.com/react-router/) 라이브러리를 사용해서 애플리케이션에 라우트 기반 코드 분할 설정.
- Suspense와 lazy를 사용해 Code splitting.
- 참고 링크 : https://ko.legacy.reactjs.org/docs/code-splitting.html#route-based-code-splitting


## CheckList
- `npm install —save-dev @babel/plugin-syntax-dynamic-import` npm 명령어를 통해 `dynamic-import` 설치 후 npm 재실행 필요.

