### PR TITLE
✨ feat: browser-image-compression 라이브러리 도입으로 이미지 등록시 용량 최적화 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.4.0",
+        "browser-image-compression": "^2.0.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-infinite-scroller": "^1.2.6",
@@ -5548,6 +5549,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/browser-process-hrtime": {
@@ -16601,6 +16610,11 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
     },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.4.0",
+    "browser-image-compression": "^2.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-infinite-scroller": "^1.2.6",


### PR DESCRIPTION
## Description
### 기능 설명
- `Browser-image-compression` 라이브러리에 있는 `imageCompression` 이라는 메소드를 사용해서 이미지 등록시 용량 최적화
- 이미지 압축 옵션은 최대 `1mb`, 최대 해상도 `1040px`로 지정
```js    
    const compressOption = {
      maxSizeMB: 1,
      maxWidthOrHeight: 1040,
    };
```

- Promise.all을 사용해 배열의 모든 파일 압축을 병렬로 실행
```js
    const compressedFiles = await Promise.all(
      filesArray.map(async file => {
        // browser-image-compression 라이브러리를 사용해 파일 압축
        const compressedBlob = await imageCompression(file, compressOption);
        // 압축된 파일을 새로운 File 객체로 생성
        const compressedFile = new File([compressedBlob], file.name, {
          type: file.type,
          lastModified: file.lastModified,
        });
        return compressedFile;
      }),
    );

    // 압축된 파일들을 formData에 추가
    compressedFiles.forEach(compressedFile => {
      formData.append("image", compressedFile);
    });
```
- 참고링크: [browser-image-compression](https://www.npmjs.com/package/browser-image-compression?activeTab=readme)

## CheckList
- [ ]  `npm install browser-image-compression --save` 명령어로 라이브러리 설치 부탁드립니다 💓